### PR TITLE
small optimizations and cleanup

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,0 +1,7 @@
+BoredAndDangerousTest:testDutchAuctionMint() (gas: 119168)
+BoredAndDangerousTest:testDutchAuctionRefund() (gas: 196751911)
+BoredAndDangerousTest:testOwnerMint() (gas: 77852)
+BoredAndDangerousTest:testWritelistApes() (gas: 276)
+BoredAndDangerousTest:testWritelistMintGiveawayBatch() (gas: 15726100)
+BoredAndDangerousTest:testWritelistMintGiveawayMass() (gas: 15501666)
+BoredAndDangerousTest:testWritelistMintWritersRoom() (gas: 253)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ forge test --fork-url=https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY} --
 
 To view gas usage, add the `--gas-report` flag to either of the above commands.
 
+Please run `forge snapshot` and commit the diff to see gas increase/decrease for tests. This does not show the exact gas usage of each function call, but it shows the overall gas usage per test (these should increase/decrease relative to optimizations in functions).
+
 
 ## Gas Report
 <pre>

--- a/src/BoredAndDangerous.sol
+++ b/src/BoredAndDangerous.sol
@@ -497,7 +497,13 @@ contract BoredAndDangerous is ERC721, ERC2981 {
         ) {
             revert DutchAuctionBadParamsAdmin();
         }
-        params = _params;
+        params = DutchAuctionParams({
+            startPrice: _params.startPrice,
+            endPrice: _params.endPrice,
+            priceIncrement: _params.priceIncrement,
+            startTime: _params.startTime,
+            timeIncrement: _params.timeIncrement
+        });
     }
 
     /// @notice Set writelistMintNextId


### PR DESCRIPTION
My linter went a little crazy. I believe my linter is setup to be standard style, but I can remove if needed.

I did a quick pass and cleaned up some functions and saved some gas (~100 gas on avg saved).

Biggest things we're unchecking totalSupply counter (this cannot feasibly overflow) and declaring struct instances as `storage` vs `memory`.
 
So rather than doing this

```
DutchAuctionMintHistory memory userMintHistory = mintHistory[msg.sender];

mintHistory[msg.sender] = DutchAuctionMintHistory({
                amount: userMintHistory.amount + uint128(amount),
                price: newPrice
});
```

We can just do 

```
DutchAuctionMintHistory storage userMintHistory = mintHistory[msg.sender];

userMintHistory.amount += uint128(amount);
userMintHistory.price = newPrice;
});
```

Here is a screenshot of a diff checker on gas saved (the difference is from running forge test from master):

<img width="1262" alt="Screen Shot 2022-07-06 at 7 15 32 PM" src="https://user-images.githubusercontent.com/103160460/177658398-85f6b725-6eca-47e9-9db2-a059da0d705d.png">

Might take a deeper look later but just some quick changes on first glance :) 

also added gas-snapshot, easier to diff check.
